### PR TITLE
Mejoras en la paralelización

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC := gcc
-CFLAGS := -Wall -Werror -Wextra -pedantic -std=c99 -O3 -march=native -std=c99
+CFLAGS := -Wall -Werror -Wextra -pedantic -std=c99 -O3 -march=native -std=c99 -ffast-math
 CLIBS := -lm -lpthread
 OMP := -fopenmp
 
@@ -11,7 +11,7 @@ OBJ := $(SRC:.c=.o)
 all: $(TARGET)
 
 $(TARGET): $(OBJ)
-	$(CC) $(CFLAGS) -o $@ $^ $(CLIBS) $(OMP)
+	$(CC) $(CFLAGS) $(OMP) -o $@ $^ $(CLIBS)
 
 %.o: %.c
 	$(CC) $(CFLAGS) $(OMP) -c -o $@ $<

--- a/src/g1D-sp-075d.c
+++ b/src/g1D-sp-075d.c
@@ -5,8 +5,6 @@
 
 int main()
 {
-    omp_set_num_threads(omp_get_num_procs());
-    
     int N_THREADS = 0, N_PART = 0, BINS = 0, steps[50], retake = 0, dump = 0;
     unsigned int Ntandas = 0u;
     char inputFilename[255], saveFilename[255];
@@ -149,14 +147,17 @@ int main()
                 p[i] = p_tmp;
             }
         }
-        // End of iter_in_range code.
-
+// End of iter_in_range code.
+#pragma omp for schedule(static)
         for (int i = 0; i < N_PART; i++)
         {
             int h_idx = (int)((2.0 * x[i] + 1) * BINS + 2.5);
             int g_idx = (int)((p[i] / 3.0e-23 + 1) * BINS + 0.5);
+#pragma omp atomic
             h[h_idx]++;
+#pragma omp atomic
             g[g_idx]++;
+#pragma omp atomic
             hg[(2 * BINS + 1) * h_idx + g_idx]++;
         }
     }

--- a/src/g1D-sp-075d.c
+++ b/src/g1D-sp-075d.c
@@ -37,7 +37,7 @@ int main()
         double numerator = 6.0E-26 * N_PART;
         double denominator = 5.24684E-24 * sqrt(2.0 * PI);
         double exponent = -pow(3.0e-23 * (1.0 * i / BINS - 1) / 5.24684E-24, 2) / 2;
-        DpE[i] = numerator / denominator * exp(exponent);
+        DpE[i] = (numerator / denominator) * exp(exponent);
     }
 
 #pragma omp parallel for simd

--- a/src/utils.c
+++ b/src/utils.c
@@ -57,6 +57,7 @@ void read_data(char filename[], double *x, double *p, int *evolution, int N_PART
 void energy_sum(double *p, int N_PART, int evolution, double M)
 {
     double sumEnergy = 0;
+#pragma omp parallel for reduction(+ : sumEnergy)
     for (int i = 0; i < N_PART; i++)
     {
         sumEnergy += p[i] * p[i];
@@ -161,6 +162,7 @@ int make_hist(int *h, int *g, int *hg, double *DxE, double *DpE, const char *fil
 
     if (strcmp(filename, "X0000000.dat") == 0)
     {
+#pragma omp parallel for reduction(+ : chi2x)
         for (int i = BINS + 1; i <= 2 * BINS; i++)
         {
             chi2x += pow(h[i] - 2 * DxE[i], 2) / (2 * DxE[i]);
@@ -169,6 +171,7 @@ int make_hist(int *h, int *g, int *hg, double *DxE, double *DpE, const char *fil
     }
     else
     {
+#pragma omp parallel for reduction(+ : chi2x)
         for (int i = 2; i <= 2 * (BINS + 1); i++)
         {
             chi2x += pow(h[i] - DxE[i], 2) / DxE[i];
@@ -176,15 +179,18 @@ int make_hist(int *h, int *g, int *hg, double *DxE, double *DpE, const char *fil
         chi2x = chi2x / (2.0 * BINS + 1);
         chi2xr = chi2x; // chi2xr = chi2x reducido
     }
+#pragma omp parallel for reduction(+ : chi2p)
     for (int i = 0; i <= 2 * (BINS - BORDES); i++)
     {
         chi2p += pow(g[i + BORDES] - DpE[i + BORDES], 2) / DpE[i + BORDES];
     }
+#pragma omp parallel for reduction(+ : chiIp, chiPp)
     for (int i = 0; i < (BINS - BORDES); i++)
     {
         chiIp += pow(g[i + BORDES] - g[2 * BINS - BORDES - i], 2) / DpE[i + BORDES];
         chiPp += pow(g[i + BORDES] + g[2 * BINS - BORDES - i] - 2.0 * DpE[i + BORDES], 2) / DpE[i + BORDES];
     }
+#pragma omp parallel for reduction(+ : chiIx, chiPx)
     for (int i = 2; i < BINS + 1; i++)
     {
         chiIx += pow(h[i] - h[2 * BINS + 4 - i], 2) / DxE[i];


### PR DESCRIPTION
Se agregaron mas loops que corran en paralelo.
Además se quito el limitante de la cantidad de threads que ejecutan la simulación.
Se puso flag -ffast-math para acelerar los calculos.
Se desambiguo un cálculo que se realizaba en la función main.