### PR TITLE
Correcion de error en d_xorshift y mejora en performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC := gcc
-CFLAGS := -Wall -Werror -Wextra -pedantic -std=c99 -O3 -march=native -ffast-math
+CFLAGS := -Wall -Werror -Wextra -pedantic -std=c99 -O3 -march=native -ffast-math -g
 CLIBS := -lm -lpthread
 OMP := -fopenmp
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -9,7 +9,15 @@
 #include <string.h>
 #include <time.h>
 
-uint32_t d_xorshift(uint32_t *state);
+inline double d_xorshift(uint32_t *state)
+{
+    uint32_t x = *state;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    *state = x;
+    return (double)x / (double)UINT32_MAX;
+}
 
 void load_parameters_from_file(char filename[], int *N_PART, int *BINS, double *DT, double *M, int *N_THREADS,
                                unsigned int *Ntandas, int steps[], char inputFilename[], char saveFilename[],

--- a/src/g1D-sp-075d.c
+++ b/src/g1D-sp-075d.c
@@ -128,7 +128,7 @@ int main()
                     k = trunc(x_tmp + 0.5 * signop);
                     if (k != 0)
                     {
-                        x_tmp = ((-2.0 * (k % 2)) + 1.0) * (x_tmp - k); // equal to x_tmp = (k % 2 ? -1.0 : 1.0) * (x_tmp - k);
+                        x_tmp = (k % 2 ? -1.0 : 1.0) * (x_tmp - k);
                         if (fabs(x_tmp) > 0.502)
                         {
                             x_tmp = 1.004 * copysign(1.0, x_tmp) - x_tmp;
@@ -140,7 +140,7 @@ int main()
                             double randomValue = d_xorshift(&seed);
                             p_tmp = sqrt(p_tmp * p_tmp + DeltaE * (randomValue - 0.5));
                         }
-                        p_tmp *= ((-2.0 * (k % 2)) + 1.0) * signop; // equal to p_tmp *= (k % 2 ? -1.0 : 1.0) * signop;
+                        p_tmp *= (k % 2 ? -1.0 : 1.0) * signop;
                     }
                 }
                 x[i] = x_tmp;

--- a/src/g1D-sp-075d.c
+++ b/src/g1D-sp-075d.c
@@ -128,7 +128,7 @@ int main()
                     k = trunc(x_tmp + 0.5 * signop);
                     if (k != 0)
                     {
-                        x_tmp = (k % 2 ? -1.0 : 1.0) * (x_tmp - k);
+                        x_tmp = ((-2.0 * (k % 2)) + 1.0) * (x_tmp - k); // equal to x_tmp = (k % 2 ? -1.0 : 1.0) * (x_tmp - k);
                         if (fabs(x_tmp) > 0.502)
                         {
                             x_tmp = 1.004 * copysign(1.0, x_tmp) - x_tmp;
@@ -140,7 +140,7 @@ int main()
                             double randomValue = d_xorshift(&seed);
                             p_tmp = sqrt(p_tmp * p_tmp + DeltaE * (randomValue - 0.5));
                         }
-                        p_tmp *= (k % 2 ? -1.0 : 1.0) * signop;
+                        p_tmp *= ((-2.0 * (k % 2)) + 1.0) * signop; // equal to p_tmp *= (k % 2 ? -1.0 : 1.0) * signop;
                     }
                 }
                 x[i] = x_tmp;

--- a/src/utils.c
+++ b/src/utils.c
@@ -3,18 +3,7 @@
 static double d_rand()
 {
     srand(time(NULL));
-    return (double)rand() / ((double)RAND_MAX + 1);
-}
-
-// returns a random number between 0 and 1
-uint32_t d_xorshift(uint32_t *state)
-{
-    uint32_t x = *state;
-    x ^= x << 13;
-    x ^= x >> 17;
-    x ^= x << 5;
-    *state = x;
-    return (double)x / ((double)UINT32_MAX + 1);
+    return (double)rand() / (double)RAND_MAX;
 }
 
 void load_parameters_from_file(char filename[], int *N_PART, int *BINS, double *DT, double *M, int *N_THREADS,


### PR DESCRIPTION
Se corrigio el valor de retorno de `d_xorshift` ya que no retornaba un `double`.
y la funcion se hizo explicitamente inline en el codigo, y mejoro notablemente la performance de la simulacion.

Tambien se hizo que no se le sume 1 a RAND_MAX y UINT32_MAX porque seguramente produce overflow.